### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete URL substring sanitization

### DIFF
--- a/scripts/goabroad_spider.py
+++ b/scripts/goabroad_spider.py
@@ -63,7 +63,7 @@ class GoAbroadSpider(scrapy.Spider):
 
         # Extract and normalize internal links for further crawling.
         internal_links = response.css("a::attr(href)").getall()
-        internal_links = [response.urljoin(link) for link in internal_links if urlparse(response.urljoin(link)).hostname is not None and urlparse(response.urljoin(link)).hostname.endswith("goabroad.csusb.edu")]
+        internal_links = [response.urljoin(link) for link in internal_links if urlparse(response.urljoin(link)).hostname is not None and (urlparse(response.urljoin(link)).hostname == "goabroad.csusb.edu" or urlparse(response.urljoin(link)).hostname.endswith(".goabroad.csusb.edu"))]
         # Deduplicate internal links.
         internal_links = list(set(internal_links))
 


### PR DESCRIPTION
Potential fix for [https://github.com/DrAlzahraniProjects/csusb_spring2025_cse6550_team2/security/code-scanning/2](https://github.com/DrAlzahraniProjects/csusb_spring2025_cse6550_team2/security/code-scanning/2)

To fix the problem, we need to ensure that the hostname check is robust and only allows the intended domain and its subdomains. We can achieve this by using `urlparse` to parse the URL and then checking if the hostname ends with ".goabroad.csusb.edu" or is exactly "goabroad.csusb.edu". This will prevent bypassing the check with malicious URLs.

1. Parse the URL using `urlparse`.
2. Extract the hostname from the parsed URL.
3. Check if the hostname is exactly "goabroad.csusb.edu" or ends with ".goabroad.csusb.edu".


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
